### PR TITLE
rootfs-adm64-dev: use -joliet-long option for mkisofs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -401,7 +401,7 @@ COPY --link --from=init-amd64-dev /out/init /rootfs/sbin/init
 COPY --link --from=vmtouch-amd64-dev /out/vmtouch /rootfs/bin/
 COPY --link --from=tini-amd64-dev /out/tini /rootfs/sbin/tini
 RUN mkdir -p /rootfs/proc /rootfs/sys /rootfs/mnt /rootfs/run /rootfs/tmp /rootfs/dev /rootfs/var /rootfs/etc && mknod /rootfs/dev/null c 1 3 && chmod 666 /rootfs/dev/null
-RUN mkdir /out/ && mkisofs -l -J -R -o /out/rootfs.bin /rootfs/
+RUN mkdir /out/ && mkisofs -joliet-long -l -J -R -o /out/rootfs.bin /rootfs/
 # RUN isoinfo -i /out/rootfs.bin -l
 
 FROM ubuntu:22.04 AS bochs-config-dev


### PR DESCRIPTION
Support long Joiet filenames for amd64 dev.

According to https://linux.die.net/man/8/mkisofs:

-joliet-long
Allow Joliet filenames to be up to 103 Unicode characters. This breaks the Joliet specification - but appears to work. Use with caution. The number 103 is derived from: the maximum Directory Record Length (254), minus the length of Directory Record (33), minus CD-ROM XA System Use Extension Information (14), divided by the UTF-16 character size (2).